### PR TITLE
[fix] bug in pretrain_result.csv

### DIFF
--- a/src/models/common.py
+++ b/src/models/common.py
@@ -274,7 +274,7 @@ class BASE(pl.LightningModule):
                 pair_rating, self.storage.max_rating, self.storage.min_rating
             )
             self.outputs_test_step["rating"] += rating
-            self.outputs_test_step["rating_predict"] += rating_predict
+            self.outputs_test_step["rating_predict_subtask"] += rating_predict
 
         # Text metrics
         self.list_tokens_predict.extend(tokens_predict)
@@ -407,6 +407,7 @@ class BASE(pl.LightningModule):
         non_score_cols = [
             "rating",
             "rating_predict",
+            "rating_predict_subtask",
             "rating_input",
             "text",
             "text_predict",

--- a/src/models/pepler.py
+++ b/src/models/pepler.py
@@ -479,6 +479,8 @@ class PEPLER(BASE):
                 assert (
                     rating_pred is not None
                 ), "rating_pred should be included"
+                if rating_pred.dim() == 0:  # when last batch size is 1
+                    rating_pred = rating_pred.unsqueeze(0)
                 rating_predict.extend(rating_pred.tolist())
             else:
                 outputs, _, _ = self.forward(

--- a/src/models/peter.py
+++ b/src/models/peter.py
@@ -526,10 +526,9 @@ class PETER(BASE):
                 ), "rating_pred should be included"
                 if isinstance(rating_pred, tuple):
                     rating_pred = rating_pred[0]
-                if isinstance(rating_pred.tolist(), float):
-                    rating_predict.append(rating_pred.tolist())
-                else:
-                    rating_predict.extend(rating_pred.tolist())
+                if rating_pred.dim() == 0:  # when last batch size is 1
+                    rating_pred = rating_pred.unsqueeze(0)
+                rating_predict.extend(rating_pred.tolist())
 
                 context = self.predict(
                     log_context_dis, topk=self.max_seq_len

--- a/src/models/peter.py
+++ b/src/models/peter.py
@@ -526,7 +526,10 @@ class PETER(BASE):
                 ), "rating_pred should be included"
                 if isinstance(rating_pred, tuple):
                     rating_pred = rating_pred[0]
-                rating_predict.extend(rating_pred.tolist())
+                if isinstance(rating_pred.tolist(), float):
+                    rating_predict.append(rating_pred.tolist())
+                else:
+                    rating_predict.extend(rating_pred.tolist())
 
                 context = self.predict(
                     log_context_dis, topk=self.max_seq_len


### PR DESCRIPTION
There was no bug, but the difference between `rating_predict` by an individually pre-trained model and by the generation model as a subtask.
-> clarified in this PR.
https://github.com/jchanxtarov/sent_xrec/issues/4

![image](https://github.com/user-attachments/assets/e0a35fb2-aada-4140-a3f0-7cd7ab6e60ca)

![image](https://github.com/user-attachments/assets/49af05c3-a613-439e-9774-d4743fefbb81)
